### PR TITLE
lib: add SLIB allocator

### DIFF
--- a/arch/lib/Kconfig
+++ b/arch/lib/Kconfig
@@ -110,6 +110,9 @@ config PROC_SYSCTL
 config NETDEVICES
        def_bool y
 
+config SLIB
+       def_bool y
+
 source "net/Kconfig"
 
 source "drivers/base/Kconfig"

--- a/arch/lib/Makefile
+++ b/arch/lib/Makefile
@@ -36,7 +36,7 @@ clean-files	:= crc32table.h
 LIB_SRC=\
 lib.c lib-device.c lib-socket.c random.c softirq.c time.c \
 timer.c hrtimer.c sched.c workqueue.c \
-print.c slab.c tasklet.c tasklet-hrtimer.c \
+print.c tasklet.c tasklet-hrtimer.c \
 glue.c fs.c sysctl.c proc.c sysfs.c \
 capability.c pid.c modules.c filemap.c vmscan.c
 
@@ -108,7 +108,7 @@ kernel/time/_to_keep=time.o
 kernel/rcu_to_keep=rcu/srcu.o rcu/pdate.o rcu/tiny.o
 kernel/locking_to_keep=locking/mutex.o
 kernel/bpf_to_keep=bpf/core.o
-mm/_to_keep=util.o list_lru.o
+mm/_to_keep=util.o list_lru.o slib.o
 crypto/_to_keep=aead.o ahash.o shash.o api.o algapi.o cipher.o compress.o proc.o \
 crc32c_generic.o
 drivers/base/_to_keep=class.o core.o bus.o dd.o driver.o devres.o module.o map.o

--- a/include/linux/slab.h
+++ b/include/linux/slab.h
@@ -191,7 +191,7 @@ size_t ksize(const void *);
 #endif
 #endif
 
-#ifdef CONFIG_SLOB
+#if defined(CONFIG_SLOB) || defined(CONFIG_SLIB)
 /*
  * SLOB passes all requests larger than one page to the page allocator.
  * No kmalloc array is necessary since objects of different sizes can
@@ -199,14 +199,6 @@ size_t ksize(const void *);
  */
 #define KMALLOC_SHIFT_HIGH	PAGE_SHIFT
 #define KMALLOC_SHIFT_MAX	30
-#ifndef KMALLOC_SHIFT_LOW
-#define KMALLOC_SHIFT_LOW	3
-#endif
-#endif
-
-#ifdef CONFIG_LIB
-#define KMALLOC_SHIFT_MAX	30
-#define KMALLOC_SHIFT_HIGH	PAGE_SHIFT
 #ifndef KMALLOC_SHIFT_LOW
 #define KMALLOC_SHIFT_LOW	3
 #endif
@@ -364,8 +356,8 @@ kmalloc_order_trace(size_t size, gfp_t flags, unsigned int order)
 }
 #endif
 
-#ifdef CONFIG_LIB
-#include <asm/slab.h>
+#ifdef CONFIG_SLIB
+#include <linux/slib_def.h>
 #else
 static __always_inline void *kmalloc_large(size_t size, gfp_t flags)
 {
@@ -445,7 +437,7 @@ static __always_inline void *kmalloc(size_t size, gfp_t flags)
 	}
 	return __kmalloc(size, flags);
 }
-#endif
+#endif /* CONFIG_SLIB */
 
 /*
  * Determine size used for the nth kmalloc cache.

--- a/include/linux/slib_def.h
+++ b/include/linux/slib_def.h
@@ -1,5 +1,5 @@
-#ifndef _ASM_SIM_SLAB_H
-#define _ASM_SIM_SLAB_H
+#ifndef _LINUX_SLLB_DEF_H
+#define _LINUX_SLLB_DEF_H
 
 
 struct kmem_cache {
@@ -18,4 +18,4 @@ static __always_inline void *kmalloc(size_t size, gfp_t flags)
 	return __kmalloc(size, flags);
 }
 
-#endif /* _ASM_SIM_SLAB_H */
+#endif /* _LINUX_SLLB_DEF_H */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1700,6 +1700,14 @@ config SLOB
 	   allocator. SLOB is generally more space efficient but
 	   does not perform as well on large systems.
 
+config SLIB
+	bool "SLIB (Library Allocator)"
+	depends on LIB
+	help
+	   SLIB replaces the slab allocator with a registered allocator
+	   function via lib_init() used by libos (CONFIG_LIB). It usually
+	   used malloc(3) or any allocators.
+
 endchoice
 
 config SLUB_CPU_PARTIAL

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -46,6 +46,7 @@ obj-$(CONFIG_NUMA) 	+= mempolicy.o
 obj-$(CONFIG_SPARSEMEM)	+= sparse.o
 obj-$(CONFIG_SPARSEMEM_VMEMMAP) += sparse-vmemmap.o
 obj-$(CONFIG_SLOB) += slob.o
+obj-$(CONFIG_SLIB) += slib.o
 obj-$(CONFIG_MMU_NOTIFIER) += mmu_notifier.o
 obj-$(CONFIG_KSM) += ksm.o
 obj-$(CONFIG_PAGE_POISONING) += debug-pagealloc.o

--- a/mm/slab.h
+++ b/mm/slab.h
@@ -37,6 +37,10 @@ struct kmem_cache {
 #include <linux/slub_def.h>
 #endif
 
+#ifdef CONFIG_SLIB
+#include <linux/slib_def.h>
+#endif
+
 #include <linux/memcontrol.h>
 
 /*

--- a/mm/slib.c
+++ b/mm/slib.c
@@ -1,5 +1,6 @@
 /*
- * glue code for library version of Linux kernel
+ * Library Slab Allocator (SLIB)
+ *
  * Copyright (c) 2015 INRIA, Hajime Tazaki
  *
  * Author: Mathieu Lacage <mathieu.lacage@gmail.com>
@@ -11,6 +12,7 @@
 #include <linux/page-flags.h>
 #include <linux/types.h>
 #include <linux/slab.h>
+#include <linux/slib_def.h>
 
 /* glues */
 struct kmem_cache *files_cachep;


### PR DESCRIPTION
SLIB allocator provides an allocator used by libos. an allocator is
registered by libos API (lib_init()): right now NUSE uses malloc(3) and
DCE uses its own Kingsley allocator to manage simulated processes.

Signed-off-by: Hajime Tazaki <tazaki@sfc.wide.ad.jp>