### PR TITLE
lib: fix dependency detection of kernel/time/timeconst.h

### DIFF
--- a/arch/lib/Makefile
+++ b/arch/lib/Makefile
@@ -135,7 +135,7 @@ $(ARCH_DIR)/linker.lds: $(ARCH_DIR)/generate-linker-script.py
 	$(call if_changed,linker)
 
 # calll kernel/time/Makefile
-kernel/time/timeconst.h:
+kernel/time/timeconst.h: $(srctree)/.config
 	$(Q) $(MAKE) $(build)=kernel/time $@
 
 # call lib/Makefile


### PR DESCRIPTION
if you had the following steps, timeconst.h won't be updated during
libos build because of the lack of dependency check in Makefile.

make allnoconfig
(change HZ to 1000)
make vmlinux
make defconfig ARCH=lib
make library ARCH=lib

Signed-off-by: Hajime Tazaki <tazaki@sfc.wide.ad.jp>